### PR TITLE
Escape '@' character in file names

### DIFF
--- a/Sources/FakeBundle/FakeBundle.swift
+++ b/Sources/FakeBundle/FakeBundle.swift
@@ -31,7 +31,7 @@ func makeFileCode(name: String, filename: String, contentsBase64: String) -> Str
 // MARK: - File traversal logic
 
 func makeTypeName(filename: String) -> String {
-    return filename.replacingOccurrences(of: ".", with: "_").replacingOccurrences(of: " ", with: "__").replacingOccurrences(of: "-", with: "___").capitalized
+    return filename.replacingOccurrences(of: ".", with: "_").replacingOccurrences(of: " ", with: "__").replacingOccurrences(of: "-", with: "___").replacingOccurrences(of: "@", with: "____").capitalized
 }
 
 func generateCode(inputUrl: URL, outputUrl: URL) throws {


### PR DESCRIPTION
Typically used to specify scale factor of images.