### PR TITLE
Update README.md to reflect new Mint syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ As Swift Package Manager does not support Resources or `Bundle` for Swift execut
 
 ## Usage with [Mint](https://github.com/yonaskolb/mint) 🌱
 
-    $ mint run zweigraf/FakeBundle "fakebundle --input ./Resources --output ./Resources.swift"
+    $ mint run zweigraf/FakeBundle fakebundle --input ./Resources --output ./Resources.swift
 
 ## Use Case
 


### PR DESCRIPTION
In older versions of Mint, when invoking a command you surrounded it in
quotation marks. That is no longer the case.