### PR TITLE
Update package dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,17 +6,17 @@
         "repositoryURL": "https://github.com/kylef/Commander.git",
         "state": {
           "branch": null,
-          "revision": "e0cbee1bd73778c1076c675eaf660e97d09f3b32",
-          "version": null
+          "revision": "e5b50ad7b2e91eeb828393e89b03577b16be7db9",
+          "version": "0.8.0"
         }
       },
       {
         "package": "PathKit",
-        "repositoryURL": "https://github.com/PoissonBallon/PathKit.git",
+        "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
-          "branch": "master",
-          "revision": "0b109bc868e9a12bc5f23e9d61ec937c75900c40",
-          "version": null
+          "branch": null,
+          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
+          "version": "1.0.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
           "branch": null,
-          "revision": "e34d5687e1e9d865e3527dd58bc2f7464ef6d936",
-          "version": "0.8.0"
+          "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
+          "version": "0.9.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 
 import PackageDescription
 
@@ -8,9 +8,8 @@ let package = Package(
         .executable(name: "fakebundle", targets: ["fakebundle"])
     ],
     dependencies: [
-        .package(url: "https://github.com/kylef/Commander.git", .revision("e0cbee1bd73778c1076c675eaf660e97d09f3b32")),
-        // PathKit fork supporting SPM4
-        .package(url: "https://github.com/PoissonBallon/PathKit.git", .branch("master")),
+        .package(url: "https://github.com/kylef/Commander.git", from: "0.8.0"),
+        .package(url: "https://github.com/kylef/PathKit.git", from: "1.0.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
This PR makes FakeBundle work with Swift 5 by updating the package dependencies (which now work with Swift 5).